### PR TITLE
fix(typo): missing Bearer keyword at authorization header field

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -8,7 +8,7 @@ const baseURL =
 const api = axios.create({
   baseURL,
   headers: {
-    Authorization: localStorage.getItem('authToken') ?? null,
+    Authorization: `Bearer ${localStorage.getItem('authToken') ?? null}`,
   },
   withCredentials: true,
 });


### PR DESCRIPTION
- fix(auth): migrate from cookies to local storage
- fix(typo): missing Bearer keyword at authorization header field
